### PR TITLE
Fix template literal syntax in snake game variables

### DIFF
--- a/server/routes/snake.js
+++ b/server/routes/snake.js
@@ -386,7 +386,7 @@ let collected = 0;
 let running = false;
 let paused = false;
 let coinsNeeded = neededCoinsToWin;
-let coinValueLocal = ${coinValue}; // 0.05
+let coinValueLocal = coinValue; // 0.05
 let roundIdLocal = null;
 
 document.getElementById('needed').innerText = coinsNeeded;

--- a/server/routes/snake.js
+++ b/server/routes/snake.js
@@ -385,7 +385,7 @@ let obstacles = [];
 let collected = 0;
 let running = false;
 let paused = false;
-let coinsNeeded = ${neededCoinsToWin};
+let coinsNeeded = neededCoinsToWin;
 let coinValueLocal = ${coinValue}; // 0.05
 let roundIdLocal = null;
 


### PR DESCRIPTION
## Purpose
The user reported that their snake game was not displaying any images in the browser and was showing 404 errors. They indicated the game was not functioning properly and requested fixes for the graphics and image display issues.

## Code changes
- Fixed template literal syntax for `coinsNeeded` and `coinValueLocal` variables in snake.js
- Removed incorrect `${}` template literal syntax that was causing JavaScript errors
- Variables now properly reference `neededCoinsToWin` and `coinValue` without template literal wrapping

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d7c1022bc6284131b7fbf7146cd9b7dc/pixel-haven)

👀 [Preview Link](https://d7c1022bc6284131b7fbf7146cd9b7dc-pixel-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d7c1022bc6284131b7fbf7146cd9b7dc</projectId>-->
<!--<branchName>pixel-haven</branchName>-->